### PR TITLE
Fix auth pipeline and JWT claims

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -50,6 +50,8 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
         };
     });
 
+builder.Services.AddAuthorization();
+
 // Add Swagger for development
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
@@ -79,8 +81,10 @@ else
 // Enable CORS
 app.UseCors("AllowAll");
 
-// API controllers
-app.MapControllers();
+app.UseRouting();
+
+app.UseAuthentication();
+app.UseAuthorization();
 
 // Setup static files from the React build folder
 var reactBuildPath = Path.Combine(Directory.GetCurrentDirectory(), "render-bnb", "build");
@@ -92,11 +96,6 @@ if (Directory.Exists(reactBuildPath))
         RequestPath = ""
     });
 
-    app.UseRouting();
-
-    app.UseAuthentication();
-    app.UseAuthorization();
-    
     // Handle all other requests by serving the React app's index.html
     app.MapFallbackToFile("index.html", new StaticFileOptions
     {
@@ -109,6 +108,9 @@ else
 }
 
 app.UseMiddleware<SpaFallbackMiddleware>(reactBuildPath);
+
+// API controllers
+app.MapControllers();
 
 app.Run();
 

--- a/Services/AuthService.cs
+++ b/Services/AuthService.cs
@@ -118,9 +118,9 @@ namespace Render_BnB_v2.Services
             
             var claims = new[]
             {
-                new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
-                new Claim(JwtRegisteredClaimNames.Name, user.Login),
-                new Claim(JwtRegisteredClaimNames.Email, user.Email),
+                new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
+                new Claim(ClaimTypes.Name, user.Login),
+                new Claim(ClaimTypes.Email, user.Email),
                 new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
             };
             


### PR DESCRIPTION
## Summary
- register authorization services and rearrange auth middleware order
- create JWT using standard ClaimTypes

## Testing
- `dotnet build --no-restore` *(fails: .NET 9 SDK missing)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6863d2484f408321888b0eb1b21650b6