### PR TITLE
Update profile picture and add logout option

### DIFF
--- a/render-bnb/src/components/DeNt/GuestPage/GHeader/GHeaderComps/Profile.js
+++ b/render-bnb/src/components/DeNt/GuestPage/GHeader/GHeaderComps/Profile.js
@@ -1,19 +1,44 @@
-import "../../../../../css/DeNt/GuestPage/GuestPage.css"
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faBars } from '@fortawesome/free-solid-svg-icons'
-import { faUser } from "@fortawesome/free-regular-svg-icons";
-import { useNavigate } from "react-router-dom";
+import "../../../../../css/DeNt/GuestPage/GuestPage.css";
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faBars } from '@fortawesome/free-solid-svg-icons';
+import { faUser } from '@fortawesome/free-regular-svg-icons';
+import { useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { logout } from '../../../../../services/authService';
+import { fetchCurrentUser } from '../../../../../services/currentUserService';
+
 function Profile() {
+    const navigate = useNavigate();
+    const [profilePic, setProfilePic] = useState(null);
 
-    return(
+    useEffect(() => {
+        fetchCurrentUser()
+            .then(u => {
+                if (u && u.profilePictureBase64) {
+                    setProfilePic(u.profilePictureBase64);
+                }
+            })
+            .catch(() => {});
+    }, []);
 
-        <div className = 'profile-wrapper'>
-            <div className = 'profile-burger-container'>
+    function handleLogout() {
+        logout();
+        navigate('/');
+    }
+
+    return (
+        <div className='profile-wrapper'>
+            <div className='profile-burger-container'>
                 <FontAwesomeIcon icon={faBars} />
             </div>
-            <div className = 'profile-user-container'>
-                <FontAwesomeIcon icon={faUser} />
+            <div className='profile-user-container'>
+                {profilePic ? (
+                    <img src={profilePic} alt='User' className='irina-user' />
+                ) : (
+                    <FontAwesomeIcon icon={faUser} />
+                )}
             </div>
+            <button className='profile-logout-btn' onClick={handleLogout}>Log Out</button>
         </div>
     );
 }

--- a/render-bnb/src/components/DeNt/GuestPage/GMain/GMainComps/GRightMain.js
+++ b/render-bnb/src/components/DeNt/GuestPage/GMain/GMainComps/GRightMain.js
@@ -1,7 +1,7 @@
 import "../../../../../css/DeNt/GuestPage/GuestPage.css";
 import { useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
-import { fetchCurrentUser } from "../../../../services/currentUserService";
+import { fetchCurrentUser } from "../../../../../services/currentUserService";
 
 function GRightMain() {
     const navigate = useNavigate();

--- a/render-bnb/src/components/Eli/Bye/Header/HeaderBye/UserByePage.js
+++ b/render-bnb/src/components/Eli/Bye/Header/HeaderBye/UserByePage.js
@@ -1,18 +1,38 @@
 import '../../../../../css/Eli/ByePage/ByePageHeader.css';
 
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faBars } from '@fortawesome/free-solid-svg-icons'
-import irina from '../../../../../img/Eli/Gallery/irina.png';
-function User() 
-{
-    return(
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faBars } from '@fortawesome/free-solid-svg-icons';
+import { faUser } from '@fortawesome/free-regular-svg-icons';
+import { useEffect, useState } from 'react';
+import { fetchCurrentUser } from '../../../../../services/currentUserService';
 
-        <div className = 'userByePage-wrap'>
-            <div className = 'burgerByePage-container'>
+function User() {
+    const [profilePic, setProfilePic] = useState(null);
+
+    useEffect(() => {
+        const token = localStorage.getItem('token');
+        if (token) {
+            fetchCurrentUser()
+                .then(u => {
+                    if (u && u.profilePictureBase64) {
+                        setProfilePic(u.profilePictureBase64);
+                    }
+                })
+                .catch(() => {});
+        }
+    }, []);
+
+    return (
+        <div className='userByePage-wrap'>
+            <div className='burgerByePage-container'>
                 <FontAwesomeIcon icon={faBars} />
             </div>
-            <div className = 'usericonByePage-container'>
-                <img src={irina} alt="Star" className="irina-userByePage" />
+            <div className='usericonByePage-container'>
+                {profilePic ? (
+                    <img src={profilePic} alt='User' className='irina-userByePage' />
+                ) : (
+                    <FontAwesomeIcon icon={faUser} />
+                )}
             </div>
         </div>
     );

--- a/render-bnb/src/components/Eli/Main/Header/HeaderComps/User.js
+++ b/render-bnb/src/components/Eli/Main/Header/HeaderComps/User.js
@@ -1,30 +1,46 @@
 import '../../../../../css/Eli/MainPage/MainPageHeader.css';
 
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faBars } from '@fortawesome/free-solid-svg-icons'
-import { faUser } from "@fortawesome/free-regular-svg-icons";
-
-import irina from '../../../../../img/Eli/Gallery/irina.png';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faBars } from '@fortawesome/free-solid-svg-icons';
+import { faUser } from '@fortawesome/free-regular-svg-icons';
 
 import { useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { fetchCurrentUser } from '../../../../../services/currentUserService';
 
-function User() 
-{
-
+function User() {
     const navigate = useNavigate();
+    const [profilePic, setProfilePic] = useState(null);
 
-    function handleClick(event) {
+    useEffect(() => {
+        const token = localStorage.getItem('token');
+        if (token) {
+            fetchCurrentUser()
+                .then(u => {
+                    if (u && u.profilePictureBase64) {
+                        setProfilePic(u.profilePictureBase64);
+                    }
+                })
+                .catch(() => {});
+        }
+    }, []);
 
-        navigate("/guestpage");
+    function handleClick() {
+        const token = localStorage.getItem('token');
+        navigate(token ? '/guestpage' : '/authpage');
     }
-    return(
 
-        <div className = 'user-wrap' onClick={handleClick}>
-            <div className = 'burger-container'>
+    return (
+        <div className='user-wrap' onClick={handleClick}>
+            <div className='burger-container'>
                 <FontAwesomeIcon icon={faBars} />
             </div>
-            <div className = 'usericon-container'>
-                <img src={irina} alt="Star" className="irina-user" />
+            <div className='usericon-container'>
+                {profilePic ? (
+                    <img src={profilePic} alt='User' className='irina-user' />
+                ) : (
+                    <FontAwesomeIcon icon={faUser} />
+                )}
             </div>
         </div>
     );

--- a/render-bnb/src/css/DeNt/GuestPage/GuestPage.css
+++ b/render-bnb/src/css/DeNt/GuestPage/GuestPage.css
@@ -123,6 +123,14 @@
     margin-right: 0.5rem;
 }
 
+.profile-logout-btn {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    font-size: 0.8rem;
+    margin-right: 0.5rem;
+}
+
 /* Header */
 
 /* Main */


### PR DESCRIPTION
## Summary
- dynamically load and display profile pictures for logged-in users
- add logout button in the profile header
- fall back to a generic user icon when no user is logged in
- ensure profile picture is fetched in several headers

## Testing
- `npm install`
- `npm test -- --watchAll=false` *(fails: require.context is not a function)*

------
https://chatgpt.com/codex/tasks/task_b_6863dfd525988321938b82ad31052954