### PR TITLE
Fix profile picture and edit form logic

### DIFF
--- a/render-bnb/src/components/DeNt/GuestPage/GMain/GMainComps/GLeftMain.js
+++ b/render-bnb/src/components/DeNt/GuestPage/GMain/GMainComps/GLeftMain.js
@@ -3,12 +3,23 @@ import pfp from "../../../../../assets/imgs/DeNt/GuestPage/Ellipse682.png"
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCheck } from "@fortawesome/free-solid-svg-icons";
 import { useNavigate } from 'react-router-dom';
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { fetchCurrentUser } from "../../../../../services/currentUserService";
 
 function GLeftMain() {
 
     const navigate = useNavigate();
+    const [profilePic, setProfilePic] = useState(null);
+
+    useEffect(() => {
+        fetchCurrentUser()
+            .then(u => {
+                if (u && u.profilePictureBase64) {
+                    setProfilePic(u.profilePictureBase64);
+                }
+            })
+            .catch(() => {});
+    }, []);
 
     function handleClick(event) {
 
@@ -21,7 +32,7 @@ function GLeftMain() {
             <div className="left-main-top-section-container">
                 <div className="left-main-top-section-box">
                     <div className="left-main-top-section-pfp-container">
-                        <img src={pfp} alt = 'pfp'/>
+                        <img src={profilePic || pfp} alt='pfp'/>
                     </div>
                     <div className="left-main-top-section-name-container">
                         <div className="left-main-top-section-name-text">

--- a/render-bnb/src/components/DeNt/GuestPage/GMain/GMainComps/GRightMain.js
+++ b/render-bnb/src/components/DeNt/GuestPage/GMain/GMainComps/GRightMain.js
@@ -1,30 +1,14 @@
 import "../../../../../css/DeNt/GuestPage/GuestPage.css";
 import { useNavigate } from "react-router-dom";
-import { useEffect, useState } from "react";
-import { fetchCurrentUser } from "../../../../../services/currentUserService";
 
 function GRightMain() {
     const navigate = useNavigate();
-    const [profile, setProfile] = useState(null);
-
-    useEffect(() => {
-        fetchCurrentUser().then(setProfile).catch(() => {});
-    }, []);
-
     function handleClickProf() {
         navigate("/profeditpage");
     }
 
     return(
         <div className="right-main-wrapper">
-            {profile && (
-                <div className="profile-info-form">
-                    <div>Університет: {profile.university}</div>
-                    <div>Мови: {profile.languages}</div>
-                    <div>Професія: {profile.job}</div>
-                    <div>Цікавий факт: {profile.funFact}</div>
-                </div>
-            )}
             <div className="right-main-content-container">
                 <div className="right-main-content-text-container">
                     <div style = {{marginTop: 15, fontSize: 20}} className="right-main-text">

--- a/render-bnb/src/components/DeNt/ProfEditPage/ProfMain/ProfMain.js
+++ b/render-bnb/src/components/DeNt/ProfEditPage/ProfMain/ProfMain.js
@@ -1,10 +1,21 @@
 import "../../../../css/DeNt/ProfEditPage/ProfEditPage.css";
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { fetchCurrentUser } from "../../../../services/currentUserService";
 import { PLeftMain } from "./ProfMainComps/PLeftMain";
 import { PRightMain } from "./ProfMainComps/PRightMain";
 
 export const ProfMain = () => {
   const [image, setImage] = useState(null);
+
+  useEffect(() => {
+    fetchCurrentUser()
+      .then(u => {
+        if (u && u.profilePictureBase64) {
+          setImage(u.profilePictureBase64);
+        }
+      })
+      .catch(() => {});
+  }, []);
 
   return (
     <div className="prof-main-wrapper">

--- a/render-bnb/src/components/DeNt/ProfEditPage/ProfMain/ProfMainComps/PLeftMain.js
+++ b/render-bnb/src/components/DeNt/ProfEditPage/ProfMain/ProfMainComps/PLeftMain.js
@@ -1,7 +1,11 @@
 import "../../../../../css/DeNt/ProfEditPage/ProfEditPage.css";
 import pfp from "../../../../../assets/imgs/DeNt//ProfEditPage/pfp.png";
+import { useEffect, useState } from "react";
+import { fetchCurrentUser } from "../../../../../services/currentUserService";
 
 export const PLeftMain = ({ image, setImage }) => {
+  const [profilePic, setProfilePic] = useState(null);
+
   const handleFile = (e) => {
     const file = e.target.files[0];
     if (!file) return;
@@ -9,20 +13,22 @@ export const PLeftMain = ({ image, setImage }) => {
     reader.onloadend = () => setImage(reader.result);
     reader.readAsDataURL(file);
   };
+
   useEffect(() => {
-          fetchCurrentUser()
-              .then(u => {
-                  if (u && u.profilePictureBase64) {
-                      setProfilePic(u.profilePictureBase64);
-                  }
-              })
-              .catch(() => {});
-      }, []);
+    fetchCurrentUser()
+      .then(u => {
+        if (u && u.profilePictureBase64) {
+          setProfilePic(u.profilePictureBase64);
+          if (!image) setImage(u.profilePictureBase64);
+        }
+      })
+      .catch(() => {});
+  }, []);
 
   return (
     <div className="p-left-main-container">
-      <img alt="pfp" src={u.profilePictureBase64} />
+      <img alt="pfp" src={image || profilePic || pfp} />
       <input type="file" accept="image/*" onChange={handleFile} />
     </div>
   );
-}
+};

--- a/render-bnb/src/components/DeNt/ProfEditPage/ProfMain/ProfMainComps/PRightMain.js
+++ b/render-bnb/src/components/DeNt/ProfEditPage/ProfMain/ProfMainComps/PRightMain.js
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { fetchCurrentUser } from "../../../../../services/currentUserService";
 
 export const PRightMain = ({ image }) => {
   const navigate = useNavigate();
@@ -10,6 +11,29 @@ export const PRightMain = ({ image }) => {
     skill: "", time: "", job: "", lang: "",
     song: "", fact: "", bio: "", pets: ""
   });
+
+  useEffect(() => {
+    fetchCurrentUser()
+      .then(u => {
+        if (u) {
+          setProfile({
+            university: u.university || "",
+            living:     u.livingPlace || "",
+            bd:         u.birthDecade || "",
+            interest:   u.interest || "",
+            skill:      u.skill || "",
+            time:       u.timeSpent || "",
+            job:        u.job || "",
+            lang:       u.languages || "",
+            song:       u.favoriteSong || "",
+            fact:       u.funFact || "",
+            bio:        u.bioHeadline || "",
+            pets:       u.pets || ""
+          });
+        }
+      })
+      .catch(() => {});
+  }, []);
 
   // 2) Generic change handler
   const handleChange = (e) => {


### PR DESCRIPTION
## Summary
- display user-specific profile pictures in GLeftMain and PLeftMain
- remove profile info preview from GRightMain
- preload current profile data into the profile edit form

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found / require.context is not a function)*

------
https://chatgpt.com/codex/tasks/task_b_6863e51f9af4832185baea7acfbf828a