### PR TITLE
Add product tag support and filtering

### DIFF
--- a/Migrations/20250601000000_AddTagToProduct.cs
+++ b/Migrations/20250601000000_AddTagToProduct.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RenderBnBv2.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTagToProduct : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Tag",
+                table: "Products",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Tag",
+                table: "Products");
+        }
+    }
+}

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -57,6 +57,11 @@ namespace RenderBnBv2.Migrations
                         .HasMaxLength(50)
                         .HasColumnType("nvarchar(50)");
 
+                    b.Property<string>("Tag")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)");
+
                     b.Property<decimal>("Rating")
                         .HasColumnType("decimal(18,2)");
 

--- a/Models/Product.cs
+++ b/Models/Product.cs
@@ -31,6 +31,10 @@ namespace Render_BnB_v2.Models
         [Required]
         [StringLength(50)]
         public string Price { get; set; }
+
+        [Required]
+        [StringLength(50)]
+        public string Tag { get; set; }
         
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     }

--- a/Models/dtos/ProductDtos.cs
+++ b/Models/dtos/ProductDtos.cs
@@ -13,6 +13,7 @@ namespace Render_BnB_v2.Models.DTOs
         public string Description { get; set; }
         public string Days { get; set; }
         public string Price { get; set; }
+        public string Tag { get; set; }
     }
     
     public class CreateProductDto
@@ -39,6 +40,10 @@ namespace Render_BnB_v2.Models.DTOs
         [Required]
         [StringLength(50)]
         public string Price { get; set; }
+
+        [Required]
+        [StringLength(50)]
+        public string Tag { get; set; }
     }
     
     public class UpdateProductDto
@@ -64,5 +69,9 @@ namespace Render_BnB_v2.Models.DTOs
         [Required]
         [StringLength(50)]
         public string Price { get; set; }
+
+        [Required]
+        [StringLength(50)]
+        public string Tag { get; set; }
     }
 }

--- a/Services/ProductService.cs
+++ b/Services/ProductService.cs
@@ -63,7 +63,8 @@ namespace Render_BnB_v2.Services
                 Rating = product.Rating,
                 Description = product.Description,
                 Days = product.Days,
-                Price = product.Price
+                Price = product.Price,
+                Tag = product.Tag
             };
         }
         
@@ -92,6 +93,7 @@ namespace Render_BnB_v2.Services
                 Description = productDto.Description,
                 Days = productDto.Days,
                 Price = productDto.Price,
+                Tag = productDto.Tag,
                 CreatedAt = DateTime.UtcNow
             };
             
@@ -118,6 +120,7 @@ namespace Render_BnB_v2.Services
             product.Description = productDto.Description;
             product.Days = productDto.Days;
             product.Price = productDto.Price;
+            product.Tag = productDto.Tag;
             
             await _context.SaveChangesAsync();
             

--- a/render-bnb/src/components/Eli/Main/Card/CardComps.js
+++ b/render-bnb/src/components/Eli/Main/Card/CardComps.js
@@ -2,14 +2,14 @@ import React, { useState, useEffect } from 'react';
 import '../../../../css/Eli/MainPage/MainPageCard.css';
 import Card from './CardComps/Card';
 
-const CardsList = ({ isChecked }) => {
+const CardsList = ({ isChecked, selectedCategory }) => {
   const [products, setProducts] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
 
   useEffect(() => {
     fetchProducts();
-  }, []);
+  }, [selectedCategory]);
 
   const fetchProducts = async () => {
     try {
@@ -21,7 +21,11 @@ const CardsList = ({ isChecked }) => {
       }
       
       const data = await response.json();
-      setProducts(data);
+      if (selectedCategory) {
+        setProducts(data.filter(p => p.tag === selectedCategory));
+      } else {
+        setProducts(data);
+      }
       setError(null);
     } catch (err) {
       setError(err.message);

--- a/render-bnb/src/components/Eli/Main/MainPage.js
+++ b/render-bnb/src/components/Eli/Main/MainPage.js
@@ -9,14 +9,16 @@ import Footer from './Footer/FooterComp';
 const MainPage = () => 
 {
     const [isChecked, setIsChecked] = useState(false);
+    const [selectedCategory, setSelectedCategory] = useState('');
 
     const handleToggle = () => { setIsChecked(!isChecked); };
+    const handleCategoryChange = (cat) => { setSelectedCategory(cat); };
 
     return (
         <div className="page-wrap">
             <Header />
-            <Nav onToggle={handleToggle} /> 
-            <CardsList isChecked={isChecked} />
+            <Nav onToggle={handleToggle} selectedCategory={selectedCategory} onCategoryChange={handleCategoryChange} />
+            <CardsList isChecked={isChecked} selectedCategory={selectedCategory} />
             <Footer />
         </div>
     );

--- a/render-bnb/src/components/Eli/Main/Nav/NavComp.js
+++ b/render-bnb/src/components/Eli/Main/Nav/NavComp.js
@@ -2,12 +2,12 @@ import Category from './NavComps/Category';
 import FilterButton from './NavComps/FilterButton';
 import PriceButton from './NavComps/PriceButton';
 
-const Nav = ({ onToggle }) => 
+const Nav = ({ onToggle, selectedCategory, onCategoryChange }) =>
 {
     return (
         <div className="nav-container">
             <div className='category-container'>
-                <Category />
+                <Category selectedCategory={selectedCategory} onSelect={onCategoryChange} />
             </div>
             <div className='filter-container'>
                 <FilterButton />

--- a/render-bnb/src/components/Eli/Main/Nav/NavComps/Category.js
+++ b/render-bnb/src/components/Eli/Main/Nav/NavComps/Category.js
@@ -42,7 +42,7 @@ const categories = sortedImages.slice(0, 12).map((image, index) => ({
     name: defaultCategories[index]
 }));
 
-const Category = () => 
+const Category = ({ selectedCategory, onSelect }) =>
 {
     const categoryRef = useRef(null);
     const [showLeftArrow, setShowLeftArrow] = useState(false);
@@ -108,8 +108,9 @@ const Category = () =>
             <div className={`arrow-left ${showLeftArrow ? 'show-arrow' : ''}`} onClick={scrollLeft}></div>
             <div className="nav-category" ref={categoryRef} onScroll={updateArrows}>
                 {categories.map((category, index) => (
-                    <div 
-                        className={`category-item ${category.name === 'Біля моря' ? 'highlighted' : ''}`} 
+                    <div
+                        onClick={() => onSelect(category.name)}
+                        className={`category-item ${category.name === selectedCategory ? 'highlighted' : ''}`}
                         key={index}
                     >
                         <img src={category.image} alt={`Category ${index + 1}`} />

--- a/render-bnb/src/components/Eli/adminpanel/AdminPanel.js
+++ b/render-bnb/src/components/Eli/adminpanel/AdminPanel.js
@@ -1,6 +1,21 @@
 import React, { useState, useEffect } from 'react';
 import '../../../css/Eli/AdminPanel/AdminPanel.css';
 
+const defaultCategories = [
+  'Гарні краєвиди',
+  'Невеликі квартирі',
+  'Великі квартири',
+  'Кімнати',
+  'Хостели',
+  'Luxe',
+  'У центрі міста',
+  'Сільська місцевість',
+  'Від дизайнера',
+  'Біля моря',
+  'Особняки',
+  'Легендарне'
+];
+
 const AdminPanel = () => {
   const [products, setProducts] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -13,7 +28,8 @@ const AdminPanel = () => {
     rating: 0,
     description: '',
     days: '',
-    price: ''
+    price: '',
+    tag: ''
   });
   const [previewImage, setPreviewImage] = useState(null);
   const [error, setError] = useState(null);
@@ -52,7 +68,8 @@ const AdminPanel = () => {
         rating: product.rating,
         description: product.description,
         days: product.days,
-        price: product.price
+        price: product.price,
+        tag: product.tag
       });
       setPreviewImage(product.imageBase64);
       setEditMode(true);
@@ -64,7 +81,8 @@ const AdminPanel = () => {
         rating: 0,
         description: '',
         days: '',
-        price: ''
+        price: '',
+        tag: ''
       });
       setPreviewImage(null);
       setEditMode(false);
@@ -81,7 +99,8 @@ const AdminPanel = () => {
       rating: 0,
       description: '',
       days: '',
-      price: ''
+      price: '',
+      tag: ''
     });
     setPreviewImage(null);
   };
@@ -129,7 +148,8 @@ const AdminPanel = () => {
             rating: parseFloat(currentProduct.rating),
             description: currentProduct.description,
             days: currentProduct.days,
-            price: currentProduct.price
+            price: currentProduct.price,
+            tag: currentProduct.tag
           })
         });
         
@@ -152,7 +172,8 @@ const AdminPanel = () => {
             rating: parseFloat(currentProduct.rating),
             description: currentProduct.description,
             days: currentProduct.days,
-            price: currentProduct.price
+            price: currentProduct.price,
+            tag: currentProduct.tag
           })
         });
         
@@ -223,6 +244,7 @@ const AdminPanel = () => {
             <div className="admin-th">Опис</div>
             <div className="admin-th">Дні</div>
             <div className="admin-th">Ціна</div>
+            <div className="admin-th">Тег</div>
             <div className="admin-th actions-cell">Дії</div>
           </div>
 
@@ -239,6 +261,7 @@ const AdminPanel = () => {
                 <div className="admin-td">{product.description}</div>
                 <div className="admin-td">{product.days}</div>
                 <div className="admin-td">{product.price}</div>
+                <div className="admin-td">{product.tag}</div>
                 <div className="admin-td actions-cell">
                   <button 
                     className="admin-edit-btn"
@@ -331,13 +354,28 @@ const AdminPanel = () => {
               </div>
               <div className="admin-form-group">
                 <label>Ціна</label>
-                <input 
-                  type="text" 
-                  name="price" 
-                  value={currentProduct.price} 
+                <input
+                  type="text"
+                  name="price"
+                  value={currentProduct.price}
                   onChange={handleChange}
                   required
                 />
+              </div>
+              <div className="admin-form-group">
+                <label>Тег</label>
+                <input
+                  list="tag-list"
+                  name="tag"
+                  value={currentProduct.tag}
+                  onChange={handleChange}
+                  required
+                />
+                <datalist id="tag-list">
+                  {defaultCategories.map(cat => (
+                    <option key={cat} value={cat} />
+                  ))}
+                </datalist>
               </div>
               <div className="admin-form-actions">
                 <button type="button" className="admin-cancel-btn" onClick={handleCloseModal}>Скасувати</button>


### PR DESCRIPTION
## Summary
- support a new `Tag` field for products and expose it through DTOs and service
- add migration for Tag column
- allow admins to set a tag with autocomplete when creating or editing a product
- make categories clickable and highlight the selected option
- filter product cards by the chosen category

## Testing
- `npm install --silent`
- `CI=true npm test --silent --runInBand` *(fails: require.context is not a function)*

------
https://chatgpt.com/codex/tasks/task_b_6863f12036408321a85b0f9d05a967fa