### PR TITLE
Add default display name

### DIFF
--- a/Models/Profile.cs
+++ b/Models/Profile.cs
@@ -14,7 +14,7 @@ namespace Render_BnB_v2.Models
         public User User { get; set; }
 
         public byte[] ProfilePicture { get; set; }
-        public string DisplayName { get; set; }
+        public string DisplayName { get; set; } = "User";
         public string University { get; set; }
         public string LivingPlace { get; set; }
         public string BirthDecade { get; set; }

--- a/Services/ProfileService.cs
+++ b/Services/ProfileService.cs
@@ -48,7 +48,7 @@ namespace Render_BnB_v2.Services
             {
                 Id = profile.Id,
                 ProfilePictureBase64 = profile.ProfilePicture != null ? $"data:image/jpeg;base64,{ByteArrayToBase64(profile.ProfilePicture)}" : null,
-                DisplayName = profile.DisplayName,
+                DisplayName = profile.DisplayName ?? "User",
                 University = profile.University,
                 LivingPlace = profile.LivingPlace,
                 BirthDecade = profile.BirthDecade,
@@ -86,7 +86,14 @@ namespace Render_BnB_v2.Services
                 profile.ProfilePicture = Base64ToByteArray(dto.ProfilePictureBase64);
             }
 
-            profile.DisplayName = dto.DisplayName;
+            if (dto.DisplayName != null)
+            {
+                profile.DisplayName = dto.DisplayName;
+            }
+            else if (profile.DisplayName == null)
+            {
+                profile.DisplayName = "User";
+            }
             profile.University = dto.University;
             profile.LivingPlace = dto.LivingPlace;
             profile.BirthDecade = dto.BirthDecade;


### PR DESCRIPTION
## Summary
- set default DisplayName on Profile model
- ensure service assigns "User" when no DisplayName is provided

## Testing
- `npm test --silent`
- `dotnet build` *(fails: NETSDK1045 unsupported target)*

------
https://chatgpt.com/codex/tasks/task_b_6865d2562dc88321941a4be92c52fa52